### PR TITLE
Change Play dependency to 2.1.0 from 2.1rc4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ version := "0.2.7-SNAPSHOT"
 
 organization := "com.typesafe"
 
-scalaVersion := "2.10.0" //RC1 to harmonize with Play RC1
+scalaVersion := "2.10.0" 
 
 libraryDependencies ++= Seq(
-  "play" %% "play" % "2.1-RC4",
-  "play" %% "play-jdbc" % "2.1-RC4",
+  "play" %% "play" % "2.1.0",
+  "play" %% "play-jdbc" % "2.1.0",
   "com.typesafe" % "slick_2.10" % "1.0.0-RC2")
 


### PR DESCRIPTION
Hi, this commit just alters the build.sbt file to get play-slick working with the release version of Play 2.1
