### PR TITLE
Better convention for test datasource definition in application.conf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,24 +32,32 @@ It follows the same format as the Ebean plugin: ``slick.default="models.*"`` mea
 
 It is possible to specify individual objects like: ``slick.default="models.Users,models.Settings"``
 
-Multiple drivers
-`````````````
-You can specify multiple drivers (dev, prod, test).
-
-Default driver is set in the application.conf file with the ``db.default.driver`` property.
-You can use ``prod.db.default.driver`` for production and ``test.db.default.driver`` for tests too.
-
 DB wrapper
 `````````````
 The DB wrapper is just a thin wrapper that uses Slicks Database classes with databases in the Play Application . 
 
-This is an example usage::
+This is an example usage:
 
     import play.api.db.slick.Config.driver.simple._
 
     play.api.db.slick.DB.withSession{ implicit session =>
       Users.insert(User("fredrik","ekholdt"))
     }
+
+
+Multiple datasources and drivers
+`````````````
+You can specify multiple drivers.
+
+Default driver is set in the application.conf file with the ``db.default.driver`` property.
+You can change `default` by another datasource name, for example``db.test.driver`` for tests.
+
+Then you can use this configuration like this :
+
+	 play.api.db.slick.DB("test").withSession { implicit session =>
+	 	 Users.insert(User("fredrik","ekholdt"))
+	 }
+
 
 Copyright
 ---------

--- a/src/main/scala/play/api/db/slick/Config.scala
+++ b/src/main/scala/play/api/db/slick/Config.scala
@@ -19,9 +19,8 @@ object Config {
 
   def driverConfiguration(conf: Configuration) = {
     val driverConfKey = Play.application.mode match {     
-      case Mode.Test if(conf.getString("test.db.default.driver").isDefined) => "test.db.default.driver"
-      case Mode.Prod if(conf.getString("prod.db.default.driver").isDefined) => "prod.db.default.driver"
-      //default mode
+      case Mode.Test if(conf.getString("db.test.driver").isDefined) => "db.test.driver"
+      //default mode (for dev and prod)
       case _ => "db.default.driver"
     }
     val driverConfValue = conf.getString(driverConfKey)


### PR DESCRIPTION
This way it works like the DB trait so we can use `DB("test").withSession {...}`
to use the `test.db.*` datasource definition in application.conf

See this issue : https://github.com/freekh/play-slick/issues/19#issuecomment-13685550
