### PR TITLE
Fix for #41, DB.driver returns the driver for its database, not the driver for the default database

### DIFF
--- a/src/main/scala/play/api/db/slick/Config.scala
+++ b/src/main/scala/play/api/db/slick/Config.scala
@@ -6,9 +6,9 @@ import scala.slick.driver._
 object Config {
   lazy val driver: ExtendedDriver = driver(play.api.Play.current)
 
-  def driver(app: Application): ExtendedDriver = {
+  def driver(app: Application, dbName: String = "default"): ExtendedDriver = {
     val conf = app.configuration
-    val driverKey = "db.default.driver"
+    val driverKey = s"db.$dbName.driver"
     conf.getString(driverKey) match {
       case Some(driver) => driver  match {
         case "org.apache.derby.jdbc.EmbeddedDriver" => DerbyDriver
@@ -25,5 +25,5 @@ object Config {
         "Slick error : jdbc driver not defined in application.conf for db.default.driver key", None)
     }
   }
-  
+
 }

--- a/src/main/scala/play/api/db/slick/DB.scala
+++ b/src/main/scala/play/api/db/slick/DB.scala
@@ -21,7 +21,7 @@ object DB extends DB {
 trait DB {
   import play.api.db.{ DB => PlayDB }
 
-  def driver(implicit app: Application) = Config.driver(app)
+  def driver(implicit app: Application) = Config.driver(app, CurrentDB)
 
   def database(name: String)(implicit app: Application): Database = {
     if (app.configuration.getConfig(s"db.$name").isEmpty) app.configuration.reportError(s"db.$name", s"While loading datasource: could not find db.$name in configuration", None)

--- a/src/test/scala/play/api/db/slick/test/ConfigTest.scala
+++ b/src/test/scala/play/api/db/slick/test/ConfigTest.scala
@@ -1,0 +1,38 @@
+package play.api.db.slick.test
+
+import org.specs2.mutable._
+import play.api.test._
+import play.api.test.Helpers._
+import play.api.db._
+import play.api.Play.current
+import play.api.db.slick.Config
+
+class ConfigSpec extends Specification {
+
+  def testConfiguration = {
+    Map(
+      "db.somedb.driver" -> "org.h2.Driver",
+      "db.default.driver" -> "com.mysql.jdbc.Driver",
+      "evolutionplugin" -> "disabled")
+  }
+
+  def fakeApplication = FakeApplication(
+    withoutPlugins = Seq("play.api.db.BoneCPPlugin"),
+    additionalConfiguration = testConfiguration)
+
+  "Config.driver" should {
+    "return the driver for the given database" in {
+      running(fakeApplication) {
+        val driver = Config.driver(play.api.Play.current, "somedb")
+        driver must equalTo(scala.slick.driver.H2Driver)
+      }
+    }
+
+    "return the driver for the default database when db name is not specified" in {
+      running(fakeApplication) {
+        val driver = Config.driver(play.api.Play.current)
+        driver must equalTo(scala.slick.driver.MySQLDriver)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This makes it easier to deal with an app that connects to multiple databases using different drivers, in case you don't want to hard-code the drivers for the connections.
