### PR TITLE
piggybacks slick session onto play request, reducing boilerplate

### DIFF
--- a/samples/computer-database/app/Global.scala
+++ b/samples/computer-database/app/Global.scala
@@ -1,7 +1,8 @@
 import java.text.SimpleDateFormat
 import play.api._
-
 import models._
+import play.api.db.slick.DB
+import play.api.Play.current
 
 object Global extends GlobalSettings {
 
@@ -19,7 +20,8 @@ object InitialData {
 
   val sdf = new SimpleDateFormat("yyyy-MM-dd")
 
-  def insert() {
+  def insert(){
+   DB.withSession{ implicit s =>
     if (Computers.count == 0) {
       Seq(
         Company(Option(1L), "Apple Inc."),
@@ -643,5 +645,6 @@ object InitialData {
         Computer(Option(574L), "iPhone 4S", Option(sdf.parse("2011-10-14")), None, Option(1L))
       ).foreach(Computers.insert)
     }
+   }
   }
 }

--- a/samples/computer-database/app/controllers/Application.scala
+++ b/samples/computer-database/app/controllers/Application.scala
@@ -5,6 +5,8 @@ import play.api.mvc._
 import play.api.data._
 import play.api.data.Forms._
 import play.api.db.slick.mvc._
+import play.api.Play.current
+import play.api.db.slick.session._
 
 import views._
 import models._
@@ -12,8 +14,7 @@ import models._
 /**
  * Manage a database of computers
  */
-object Application extends Controller with SlickController { 
-  
+object Application extends Controller with DBController { 
   /**
    * This result directly redirect to the application home.
    */
@@ -46,7 +47,7 @@ object Application extends Controller with SlickController {
    * @param orderBy Column to be sorted
    * @param filter Filter applied on computer names
    */
-  def list(page: Int, orderBy: Int, filter: String) = SlickAction { implicit request =>
+  def list(page: Int, orderBy: Int, filter: String) = DBAction { implicit rs =>
     Ok(html.list(
       Computers.list(page = page, orderBy = orderBy, filter = ("%"+filter+"%")),
       orderBy, filter
@@ -58,7 +59,7 @@ object Application extends Controller with SlickController {
    *
    * @param id Id of the computer to edit
    */
-  def edit(id: Long) = SlickAction {
+  def edit(id: Long) = DBAction { implicit rs =>
     Computers.findById(id).map { computer =>
       Ok(html.editForm(id, computerForm.fill(computer), Companies.options))
     }.getOrElse(NotFound)
@@ -69,7 +70,7 @@ object Application extends Controller with SlickController {
    *
    * @param id Id of the computer to edit
    */
-  def update(id: Long) = SlickAction { implicit request =>
+  def update(id: Long) = DBAction { implicit rs =>
     computerForm.bindFromRequest.fold(
       formWithErrors => BadRequest(html.editForm(id, formWithErrors, Companies.options)),
       computer => {
@@ -82,14 +83,14 @@ object Application extends Controller with SlickController {
   /**
    * Display the 'new computer form'.
    */
-  def create = SlickAction {
+  def create = DBAction { implicit rs =>
     Ok(html.createForm(computerForm, Companies.options))
   }
   
   /**
    * Handle the 'new computer form' submission.
    */
-  def save = SlickAction { implicit request =>
+  def save = DBAction { implicit rs =>
     computerForm.bindFromRequest.fold(
       formWithErrors => BadRequest(html.createForm(formWithErrors, Companies.options)),
       computer => {
@@ -102,7 +103,7 @@ object Application extends Controller with SlickController {
   /**
    * Handle computer deletion.
    */
-  def delete(id: Long) = SlickAction {
+  def delete(id: Long) = DBAction { implicit rs =>
     Computers.delete(id)
     Home.flashing("success" -> "Computer has been deleted")
   }

--- a/samples/computer-database/test/ModelSpec.scala
+++ b/samples/computer-database/test/ModelSpec.scala
@@ -4,6 +4,9 @@ import org.specs2.mutable._
 
 import play.api.test._
 import play.api.test.Helpers._
+import play.api.db.slick.DB
+import slick.session.Session
+import play.api.Play.current
 
 class ModelSpec extends Specification {
   
@@ -19,36 +22,36 @@ class ModelSpec extends Specification {
     
     "be retrieved by id" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
-        
-        val Some(macintosh) = Computers.findById(21)
+        DB.withSession{ implicit s:Session =>
+          val Some(macintosh) = Computers.findById(21)
       
-        macintosh.name must equalTo("Macintosh")
-        macintosh.introduced must beSome.which(dateIs(_, "1984-01-24"))  
-        
+          macintosh.name must equalTo("Macintosh")
+          macintosh.introduced must beSome.which(dateIs(_, "1984-01-24"))  
+        }        
       }
     }
     
     "be listed along its companies" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         
-        val computers = Computers.list()
-
-        computers.total must equalTo(574)
-        computers.items must have length(10)
-
+        DB.withSession{ implicit s:Session =>
+          val computers = Computers.list()
+          computers.total must equalTo(574)
+          computers.items must have length(10)
+        }
       }
     }
     
     "be updated if needed" in {
       running(FakeApplication(additionalConfiguration = inMemoryDatabase())) {
         
-        Computers.update(21, Computer(name="The Macintosh", introduced=None, discontinued=None, companyId=Some(1)))
+        DB.withSession{ implicit s:Session =>
+          Computers.update(21, Computer(name="The Macintosh", introduced=None, discontinued=None, companyId=Some(1)))
         
-        val Some(macintosh) = Computers.findById(21)
-        
-        macintosh.name must equalTo("The Macintosh")
-        macintosh.introduced must beNone
-        
+          val Some(macintosh) = Computers.findById(21)
+          macintosh.name must equalTo("The Macintosh")
+          macintosh.introduced must beNone
+        }
       }
     }
     

--- a/samples/play-slick-cake-sample/app/controllers/Application.scala
+++ b/samples/play-slick-cake-sample/app/controllers/Application.scala
@@ -4,20 +4,17 @@ import play.api._
 import play.api.data._
 import play.api.data.Forms._
 import play.api.mvc._
-import play.api.db.slick.DB
+import play.api.db.slick.session._
+import play.api.db.slick.mvc._
 import models._
 
 //stable imports to use play.api.Play.current outside of objects:
 import models.current.dao._
 import models.current.dao.profile.simple._
 
-object Application extends Controller {
-  import play.api.Play.current
-
-  def index = Action {
-    DB.withSession{ implicit session =>
-      Ok(views.html.index(Query(Cats).list))
-    }
+object Application extends Controller with DBController{
+  def index = DBAction { implicit rs =>
+    Ok(views.html.index(Query(Cats).list))
   }
 
   val catForm = Form(
@@ -27,12 +24,9 @@ object Application extends Controller {
     )(Cat.apply)(Cat.unapply)
   )
   
-  def insert = Action { implicit request =>
+  def insert = DBAction { implicit rs =>
     val cat = catForm.bindFromRequest.get
-    DB.withSession{ implicit session =>
-      Cats.insert(cat)
-    }
-
+    Cats.insert(cat)
     Redirect(routes.Application.index)
   }
   

--- a/samples/play-slick-sample/app/controllers/Application.scala
+++ b/samples/play-slick-sample/app/controllers/Application.scala
@@ -3,19 +3,16 @@ package controllers
 import models._
 import play.api._
 import play.api.db.slick.Config.driver.simple._
-import play.api.db.slick.DB
+import play.api.db.slick.session._
+import play.api.db.slick.mvc._
 import play.api.data._
 import play.api.data.Forms._
 import play.api.mvc._
 
-object Application extends Controller {
+object Application extends Controller with DBController{
 
-  import play.api.Play.current
-
-  def index = Action {
-    DB.withSession{ implicit session =>
-      Ok(views.html.index(Query(Cats).list))
-    }
+  def index = DBAction { implicit rs =>
+    Ok(views.html.index(Query(Cats).list))
   }
 
   val catForm = Form(
@@ -25,11 +22,9 @@ object Application extends Controller {
     )(Cat.apply)(Cat.unapply)
   )
 
-  def insert = Action { implicit request =>
+  def insert = DBAction { implicit rs =>
     val cat = catForm.bindFromRequest.get
-    DB.withSession{ implicit session =>
-      Cats.insert(cat)
-    }
+    Cats.insert(cat)
 
     Redirect(routes.Application.index)
   }

--- a/src/main/scala/play/api/db/slick/session.scala
+++ b/src/main/scala/play/api/db/slick/session.scala
@@ -1,0 +1,7 @@
+package play.api.db.slick
+import play.api.mvc._
+package object session{
+  implicit def requestWithDbSession2request(implicit r:RequestWithDbSession): Request[AnyContent] = r.request
+  implicit def requestWithDbSession2session(implicit r:RequestWithDbSession) : slick.session.Session = r.session
+  case class RequestWithDbSession( request:Request[AnyContent], session: slick.session.Session )
+}


### PR DESCRIPTION
- renames SlickAction to DBAction (looks more seamless this way and future play users will know what DB means, but may be confused what Slick is)
- DBAction now passes a RequestWithDbSession, which combines a Play Request and a Slick Session to its argument. Two implicit conversions implicitly convert it to either of the two. This way DBAction automatically provides an implicit Session, removing the need for calling withSession explicitly every time. DBAction uses withSession internally, which provides a session object, but opens/fetches a connection lazily only on first use. The session is closed by DBAction when the request ends. To tune performance, users can close the session early at any time using its close() method. Also, users can still use withSession themselves if they want open and close sessions multiple times. This change does not only reduce boilerplate, but also makes it more transparent where databases accesses happen, because it requires a DBAction instead of an Action (unless withSession is used explicitly, which should be needed rarely).
