### PR TITLE
Add support for MSSQL jTDS driver

### DIFF
--- a/src/main/scala/play/api/db/slick/Database.scala
+++ b/src/main/scala/play/api/db/slick/Database.scala
@@ -25,6 +25,7 @@ class Database(name:String = "default", app: Application) extends PlayDatabase{
      ,"org.postgresql.Driver" -> PostgresDriver
      ,"org.sqlite.JDBC" -> SQLiteDriver
      ,"com.microsoft.sqlserver.jdbc.SQLServerDriver" -> SQLServerDriver
+     ,"net.sourceforge.jtds.jdbc.Driver" -> SQLServerDriver
   ).get(_)
   def driver = {
     val key = s"db.$name.driver"


### PR DESCRIPTION
Pull request to resolve issue freekh/play-slick#76: "Possible incompatibility with MS SQL Server JTDS".

The solution is just to add the driver name to the `driverByName` method. SQL syntax is already supported, since it's MS SQL server.

See also corresponding thread on Stack Overflow: http://stackoverflow.com/questions/18025256/connecting-to-mssql-with-play-and-slick
