### PR TITLE
feat(TableScanner): Use class-based Logger instead of play.Logger

### DIFF
--- a/samples/computer-database/project/plugins.sbt
+++ b/samples/computer-database/project/plugins.sbt
@@ -7,4 +7,4 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.0"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.2.1"))


### PR DESCRIPTION
 DDL scanning should be in the play.api.db.slick.ddl namespace; this allows runtime configuration of logging instead of blasting out the 'application' namespace.

fix(plugins.sbt): default to latest play.
