### PR TITLE
Force H2 driver registration to fix SQLException in tests

### DIFF
--- a/code/src/test/scala/play/api/db/slick/TestableDBActionTest.scala
+++ b/code/src/test/scala/play/api/db/slick/TestableDBActionTest.scala
@@ -3,6 +3,7 @@ package play.api.db.slick
 import scala.concurrent.ExecutionContext
 
 import com.jolbox.bonecp.BoneCPDataSource
+import java.sql.DriverManager
 import org.specs2.mutable._
 import play.api.test._
 import play.api.test.Helpers._
@@ -11,11 +12,11 @@ import scala.slick.driver.H2Driver
 
 class TestableDBActionSpec extends Specification {
 
-  // NOTE (2014-02-20, ms-tg): Following two lines workaround the
-  //   SQLException("No suitable driver found for jdbc:h2:mem:play")
-  //   when an H2 db has already been created in another test
-  Class.forName("org.h2.Driver")
-  java.sql.DriverManager.registerDriver(new org.h2.Driver());
+  // Force H2 driver registration, to fix "java.sql.SQLException: No suitable driver found".
+  // Probably caused by overeager driver deregistration in a previous test. It may be
+  // possible to remove this line and the line in SlickPlayIterateesFunctionalTest in the near future
+  // once a DB plugin fix makes it into Play: https://github.com/playframework/playframework/pull/2794
+  DriverManager.registerDriver(new org.h2.Driver())
 
   val datasource = new BoneCPDataSource
   datasource.setJdbcUrl("jdbc:h2:mem:play")

--- a/code/src/test/scala/play/api/db/slick/iteratees/SlickPlayIterateesFunctionalTest.scala
+++ b/code/src/test/scala/play/api/db/slick/iteratees/SlickPlayIterateesFunctionalTest.scala
@@ -6,6 +6,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Try, Random}
 
 import com.typesafe.slick.testkit.util.JdbcTestDB
+import java.sql.DriverManager
 import org.h2.jdbc.JdbcSQLException
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
@@ -20,6 +21,12 @@ class SlickPlayIterateesFunctionalTest extends Specification with NoTimeConversi
 
   // Only one test can execute at a time, as they share an in-memory H2 database
   sequential
+
+  // Force H2 driver registration, to fix "java.sql.SQLException: No suitable driver found".
+  // Probably caused by overeager driver deregistration in a previous test. It may be
+  // possible to remove this line and the line in TestableDBActionTest in the near future
+  // once a DB plugin fix makes it into Play: https://github.com/playframework/playframework/pull/2794
+  DriverManager.registerDriver(new org.h2.Driver())
 
   // Create in-memory test DB and import its implicits
   val tdb = new JdbcTestDB("h2mem") {


### PR DESCRIPTION
Running DBTest and SlickPlayIterateesFunctionalTest together reliably threw a "java.sql.SQLException: No suitable driver found". This fix forces registration of the H2 driver to make sure a driver is available.

It shouldn't be necessary to register the driver. Something is presumably deregistering a driver that it didn't register. Slick doesn't deregister drivers, so it's probably Play. There is a recent fix in Play's DB plugin that might resolve this issue: https://github.com/playframework/playframework/pull/2794. Once that issue's fixed we can try to remove this workaround from our tests.
