### PR TITLE
Test with Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@
  scala:
    - "2.10.4"
  jdk:
-   - openjdk7
    - openjdk6
+   - openjdk7
+   - oraclejdk8


### PR DESCRIPTION
Add Java 8 to the list of Java configurations for Travis to try out. If this is too slow we could remove Java 7, since Java 6 and 8 _should_ be enough testing for us.
