### PR TITLE
Move publish.sbt to code project, use standard resolvers

### DIFF
--- a/code/publish.sbt
+++ b/code/publish.sbt
@@ -38,8 +38,8 @@ pomExtra := (
 
 publishTo <<= version { v: String =>
   val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) 
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else                             
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  if (v.trim.endsWith("SNAPSHOT"))
+    Some(Opts.resolver.sonatypeSnapshots)
+  else
+    Some(Opts.resolver.sonatypeStaging)
 }


### PR DESCRIPTION
Move publish settings out of root directory, since we don't want to publish all sub-projects. Use standard resolvers to identify Sonatype repository.

I actually needed to make these changes to publish 0.7.0-M1. This PR brings the changes I made properly into master.
