### PR TITLE
Use standard snapshot versioning

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -4,7 +4,7 @@ licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.
 
 homepage := Some(url("https://github.com/playframework/play-slick"))
 
-version := "0.8.0-SNAPSHOT"
+version := "0.8-SNAPSHOT"
 
 organization := "com.typesafe.play"
 


### PR DESCRIPTION
Changing to standard snapshot versioning (x.y-SNAPSHOT) instead of (x.y.z-SNAPSHOT) means we don't need to update snapshot branches every time we tag a release.
