### PR TITLE
Update readme for 0.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Play Slick plugin supports several different versions of Play and Slick.
 | 0.5.x               | 2.2.x              | 1.0.x               | 2.10.x        |
 | 0.6.x               | 2.2.x              | 2.0.x               | 2.10.x        |
 | 0.7.x               | 2.3.x              | 2.0.x               | 2.10.x        |
-| 0.8.x (pre-release) | 2.3.x              | 2.1.x (pre-release) | 2.10.x/2.11.x |
+| 0.8.x               | 2.3.x              | 2.1.x               | 2.10.x/2.11.x |
 
 The plugin has its own release cycle and therefore is not integrated into either core Play or Slick.
 
@@ -66,7 +66,7 @@ For Play 2.3 and Slick 2.0 (with Scala 2.10):
 For Play 2.3 and Slick 2.1 **release candidate** (with Scala 2.10 or 2.11):
 
 ```scala
-"com.typesafe.play" %% "play-slick" % "0.8.0-RC3"
+"com.typesafe.play" %% "play-slick" % "0.8.0"
 ```
 
 # Copyright


### PR DESCRIPTION
To be merged once the play-slick 0.8.0 artifacts hit Maven Central. [They don't seem to be there just yet.](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.typesafe.play%22%20AND%20%28a%3A%22play-slick_2.10%22%20OR%20a%3A%22play-slick_2.11%22%29)
