### PR TITLE
Remove reference to release candidate from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For Play 2.3 and Slick 2.0 (with Scala 2.10):
 "com.typesafe.play" %% "play-slick" % "0.7.0"
 ```
 
-For Play 2.3 and Slick 2.1 **release candidate** (with Scala 2.10 or 2.11):
+For Play 2.3 and Slick 2.1 (with Scala 2.10 or 2.11):
 
 ```scala
 "com.typesafe.play" %% "play-slick" % "0.8.0"


### PR DESCRIPTION
The readme currently reads as if version 0.8.0 would still use the release candidate of Slick 2.1. This is not the case.
