### PR TITLE
Replace comma with a regexp that matches commas, newlines or comma+newlines

### DIFF
--- a/code/src/main/scala/play/api/db/slick/Config.scala
+++ b/code/src/main/scala/play/api/db/slick/Config.scala
@@ -20,7 +20,7 @@ class DefaultSlickConfig @Inject() (conf: Configuration, environment: Environmen
     (for {
       config <- conf.getConfig("slick").toSeq
       key <- config.keys
-      names = config.getString(key).getOrElse(keyNotFound(key)).split(",").toSet
+      names = config.getString(key).getOrElse(keyNotFound(key)).split("""(,\n|\n|,)""").toSet
     } yield {
       key -> names
     }).toMap


### PR DESCRIPTION
Database models can now be declared (in the config file) with newlines as well as commas. This helps keeping the config file readable when there's a lot of models to add.

I've run the tests and the only one that doesn't pass is a tests that didn't pass on my machine even when I had just cloned the repo so I think it's something due to my local configs.
