### PR TITLE
Upgraded to reflections 0.9.9

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -12,6 +12,7 @@ object CommonSettings extends AutoPlugin {
     crossScalaVersions := Seq("2.10.4", scalaVersion.value),
     scalacOptions ++= Seq("-feature", "-deprecation"),
     parallelExecution in Test := false,
-    resolvers ++= Dependencies.resolvers
+    resolvers ++= Dependencies.resolvers,
+    fork in Test := true
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Version {
   val hsqldb       = "2.3.1"
   val javaxServlet = "3.0.1"
   val mockito      = "1.9.5"
-  val reflections  = "0.9.8"
+  val reflections  = "0.9.9"
   val slick        = "2.1.0"
 }
 

--- a/src/main/scala/play/api/db/slick/ddl/ReflectionUtils.scala
+++ b/src/main/scala/play/api/db/slick/ddl/ReflectionUtils.scala
@@ -3,7 +3,6 @@ package play.api.db.slick.ddl
 import org.reflections.scanners
 import org.reflections.util
 import org.reflections.Reflections
-import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe._
 
 object ReflectionUtils {
@@ -15,7 +14,7 @@ object ReflectionUtils {
       Some(new Reflections(new util.ConfigurationBuilder()
         .addUrls(scanUrls)
         .filterInputsBy(new util.FilterBuilder().include(util.FilterBuilder.prefix(pkg + ".")))
-        .setScanners(new scanners.TypeAnnotationsScanner, new scanners.TypesScanner)))
+        .setScanners(new scanners.TypeAnnotationsScanner, new scanners.TypeElementsScanner)))
     else
       None
   }

--- a/src/main/scala/play/api/db/slick/ddl/TableScanner.scala
+++ b/src/main/scala/play/api/db/slick/ddl/TableScanner.scala
@@ -2,9 +2,6 @@ package play.api.db.slick.ddl
 
 import scala.slick.driver.JdbcDriver
 import scala.slick.lifted.AbstractTable
-import org.apache.xerces.dom3.as.ASModel
-import scala.slick.driver.JdbcProfile
-import scala.slick.lifted.Tag
 
 import scala.reflect.internal.MissingRequirementError
 import scala.reflect.runtime.universe
@@ -121,7 +118,7 @@ object TableScanner {
     import scala.collection.JavaConverters._
     ReflectionUtils.getReflections(classloader, name).map { reflections =>
       reflections.getStore //TODO: would be nicer if we did this using Scala reflection, alas staticPackage is non-deterministic:  https://issues.scala-lang.org/browse/SI-6573
-        .get(classOf[org.reflections.scanners.TypesScanner])
+        .get(classOf[org.reflections.scanners.TypeElementsScanner].getSimpleName)
         .keySet.asScala.toSet[String]
     }.toSet.flatten
   }


### PR DESCRIPTION
Since Play master has upgraded to reflections 0.9.9, this breaks when building play-slick against it due to binary incompatible changes in reflections.