### PR TITLE
Update readme and slick version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The Play Slick plugin supports several different versions of Play and Slick.
 | 0.6.x                  | 2.2.x              | 2.0.x               | 2.10.x        |
 | 0.7.x                  | 2.3.x              | 2.0.x               | 2.10.x        |
 | 0.8.x                  | 2.3.x              | 2.1.x               | 2.10.x/2.11.x |
-| 0.9.x (M4 and earlier) | 2.4.x              | 2.1.x               | 2.10.x/2.11.x |
 | 1.0.0                  | 2.4.x              | 3.0.x               | 2.10.x/2.11.x |
 
 The plugin has its own release cycle and therefore is not integrated into either core Play or Slick.
@@ -40,7 +39,9 @@ For Play 2.4 and Slick 3.0 (with Scala 2.10 or Scala 2.11):
 
 # Documentation
 
-Check the project's [wiki](https://github.com/playframework/play-slick/wiki) for details.
+The documentation for the latest release is available [here](https://www.playframework.com/documentation/2.4.x/PlaySlick).
+
+Documentation for v0.8 is available in the project's [wiki](https://github.com/playframework/play-slick/wiki).
 
 # Copyright
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The Play Slick plugin supports several different versions of Play and Slick.
 
 | Plugin version         | Play version       | Slick version       | Scala version |
 |------------------------|--------------------|---------------------|---------------|
-| 0.4.x                  | 2.1.x              | 1.0.x               | 2.10.x        |
-| 0.5.x                  | 2.2.x              | 1.0.x               | 2.10.x        |
-| 0.6.x                  | 2.2.x              | 2.0.x               | 2.10.x        |
-| 0.7.x                  | 2.3.x              | 2.0.x               | 2.10.x        |
-| 0.8.x                  | 2.3.x              | 2.1.x               | 2.10.x/2.11.x |
 | 1.0.0                  | 2.4.x              | 3.0.x               | 2.10.x/2.11.x |
+| 0.8.x                  | 2.3.x              | 2.1.x               | 2.10.x/2.11.x |
+| 0.7.x                  | 2.3.x              | 2.0.x               | 2.10.x        |
+| 0.6.x                  | 2.2.x              | 2.0.x               | 2.10.x        |
+| 0.5.x                  | 2.2.x              | 1.0.x               | 2.10.x        |
+| 0.4.x                  | 2.1.x              | 1.0.x               | 2.10.x        |
 
 The plugin has its own release cycle and therefore is not integrated into either core Play or Slick.
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Version {
   val javaxServlet = "3.0.1"
   val mockito      = "1.9.5"
   val reflections  = "0.9.9"
-  val slick        = "3.0.0-RC3"
+  val slick        = "3.0.0"
 }
 
 object Library {


### PR DESCRIPTION
* The link to the latest Play Slick doc in the README is currently broken. It will work as soon as the documentation in this repo is aggregated with the Play 2.4 doc (which should happen soon enough).