### PR TITLE
Omnidoc failure

### DIFF
--- a/src/main/scala/play/api/db/slick/DbName.scala
+++ b/src/main/scala/play/api/db/slick/DbName.scala
@@ -1,0 +1,6 @@
+package play.api.db.slick
+
+/**
+ * The name of a slick database
+ */
+case class DbName(val value: String) extends AnyVal

--- a/src/main/scala/play/api/db/slick/package.scala
+++ b/src/main/scala/play/api/db/slick/package.scala
@@ -1,7 +1,5 @@
 package play.api.db
 
 package object slick {
-  case class DbName(val value: String) extends AnyVal
-
   val IssueTracker = "https://github.com/playframework/play-slick/issues"
 }


### PR DESCRIPTION
Omnidoc nightly compilation is failing with this:

```
[error] /home/play/deploy/omnidoc/target/scala-2.10/omnidoc/sources/com.typesafe.play-play-slick_2.10-0.9.0-2015-04-30-90781ab-SNAPSHOT/play/api/db/slick/DatabaseConfigProvider.scala:81: type mismatch;
[error]  found   : play.api.db.slick.play.api.db.slick.DbName
[error]  required: play.api.db.slick.(some other)play.api.db.slick.DbName
[error]       slickApi.dbConfig[P](DbName(dbName))
[error]                                  ^
[error] /home/play/deploy/omnidoc/target/scala-2.10/omnidoc/sources/com.typesafe.play-play-slick_2.10-0.9.0-2015-04-30-90781ab-SNAPSHOT/play/api/db/slick/SlickApi.scala:54: type mismatch;
[error]  found   : scala.collection.generic.CanBuildFrom[Any,Char,String]
[error]  required: scala.collection.generic.CanBuildFrom[scala.collection.immutable.Map[String,com.typesafe.config.Config],(play.api.db.slick.play.api.db.slick.DbName, play.api.db.slick.DefaultSlickApi.DatabaseConfigFactory),Map[play.api.db.slick.(some other)play.api.db.slick.DbName,play.api.db.slick.DefaultSlickApi.DatabaseConfigFactory]]
[error]       (DbName(name), new DatabaseConfigFactory(name, config, lifecycle)))(collection.breakOut)
[error]                                                                                      ^
[error] /home/play/deploy/omnidoc/target/scala-2.10/omnidoc/sources/com.typesafe.play-play-slick_2.10-0.9.0-2015-04-30-90781ab-SNAPSHOT/play/api/db/slick/SlickModule.scala:62: type mismatch;
[error]  found   : play.api.db.slick.play.api.db.slick.DbName
[error]  required: play.api.db.slick.(some other)play.api.db.slick.DbName
[error]     def get[P <: BasicProfile]: DatabaseConfig[P] = slickApi.dbConfig[P](DbName(name))
[error]                                                                                ^
[error] /home/play/deploy/omnidoc/target/scala-2.10/omnidoc/sources/com.typesafe.play-play-slick_2.10-0.9.0-2015-04-30-90781ab-SNAPSHOT/play/api/db/slick/internal/DBApiAdapter.scala:27: type mismatch;
[error]  found   : play.api.db.slick.play.api.db.slick.DbName
[error]  required: play.api.db.slick.(some other)play.api.db.slick.DbName
[error]     databasesByName.getOrElse(DbName(name), throw new IllegalArgumentException(s"Could not find database for $name"))
[error]                                     ^
```

Note, the omnidoc build differs from a normal build in that it's doing a scaladoc compile over the entire aggregated sources of Play, play-slick, anorm, twirl and play-ebean.  This can often cause failures that don't show up in regular compilation because the additional sources can introduce ambiguities.