### PR TITLE
(docs) replace 'SPI' with 'specification'

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/slick/PlaySlickMigrationGuide.md
+++ b/docs/manual/working/scalaGuide/main/sql/slick/PlaySlickMigrationGuide.md
@@ -107,13 +107,14 @@ The `Config` object, together with `SlickConfig` and `DefaultSlickConfig`, were 
 
 ## `SlickPlayIteratees` was removed
 
-If you were using `SlickPlayIteratees.enumerateSlickQuery` to stream data from the database, you will be happy to know that doing so became a lot easier. Slick 3 implements the [reactive-streams] SPI, and Play 2.4 provides a utility class to handily convert a reactive stream into a Play enumerator.
+If you were using `SlickPlayIteratees.enumerateSlickQuery` to stream data from the database, you will be happy to know that doing so became a lot easier. Slick 3 implements the [reactive-streams] [SPI] (Service Provider Interface), and Play 2.4 provides a utility class to handily convert a reactive stream into a Play enumerator.
 
 In Slick, you can obtain a reactive stream by calling the method `stream` on a Slick database instance (instead of the eager `run`). To convert the stream into an enumerator simply call `play.api.libs.streams.Streams.publisherToEnumerator`, passing the stream in argument.
 
 For a full example, have a look at [this sample projet](https://github.com/playframework/play-slick/tree/master/samples/iteratee).
 
 [reactive-streams]: http://www.reactive-streams.org/
+[SPI]: http://en.wikipedia.org/wiki/Service_provider_interface
 
 ## DDL support was removed
 


### PR DESCRIPTION
I assume you meant in implements the specification, rather than the SPI, which I believe refers to the _Special Interest Group_ for Reactive Streams? (or did you mean API)?