### PR TITLE
(docs typo: 'projet' -> 'project')

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/slick/PlaySlickMigrationGuide.md
+++ b/docs/manual/working/scalaGuide/main/sql/slick/PlaySlickMigrationGuide.md
@@ -111,7 +111,7 @@ If you were using `SlickPlayIteratees.enumerateSlickQuery` to stream data from t
 
 In Slick, you can obtain a reactive stream by calling the method `stream` on a Slick database instance (instead of the eager `run`). To convert the stream into an enumerator simply call `play.api.libs.streams.Streams.publisherToEnumerator`, passing the stream in argument.
 
-For a full example, have a look at [this sample projet](https://github.com/playframework/play-slick/tree/master/samples/iteratee).
+For a full example, have a look at [this sample project](https://github.com/playframework/play-slick/tree/master/samples/iteratee).
 
 [reactive-streams]: http://www.reactive-streams.org/
 


### PR DESCRIPTION
Thanks all who ported my sample project here to the new Reactive Streams system. It really makes it a lot easier to understand the changes. Especially thanks for keeping the test working.