### PR TITLE
Project compiles against Slick 3.1.0-M1

### DIFF
--- a/src/core/src/main/scala/play/api/db/slick/SlickApi.scala
+++ b/src/core/src/main/scala/play/api/db/slick/SlickApi.scala
@@ -86,7 +86,7 @@ object DefaultSlickApi {
 
     @throws(classOf[PlayException])
     private def create(): DatabaseConfig[BasicProfile] = {
-      try DatabaseConfig.forConfig[BasicProfile](path = "", config)
+      try DatabaseConfig.forConfig[BasicProfile](path = "", config = config)
       catch {
         case NonFatal(t) =>
           logger.error(s"Failed to create Slick database config for key $name.", t)


### PR DESCRIPTION
This is a small change needed to compile the codebase with Slick 3.1.0-M1.

Without this change, scalac was reporting the following error:

  parameter 'config' is already specified at parameter position 2

This may be a compiler bug, as it is quite similar to SI-8117 \cc @lrytz
@adriaanm