### PR TITLE
Fix connection leak when using Play-Evolution

### DIFF
--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
@@ -48,7 +48,7 @@ private[evolutions] object DBApiAdapter {
           throw new UnsupportedOperationException
       }
     }
-    def url: String = dbConfig.db.createSession().metaData.getURL
+    def url: String = dbConfig.db.withSession { _.metaData.getURL }
     def getConnection(): Connection = {
       val session = dbConfig.db.createSession()
       session.conn

--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
@@ -49,10 +49,7 @@ private[evolutions] object DBApiAdapter {
       }
     }
     def url: String = dbConfig.db.withSession { _.metaData.getURL }
-    def getConnection(): Connection = {
-      val session = dbConfig.db.createSession()
-      session.conn
-    }
+    def getConnection(): Connection = dbConfig.db.source.createConnection()
     def getConnection(autocommit: Boolean): Connection = getConnection() // FIXME: auto-commit is ignored (in slick, I believe auto-commit is on by default, but need to double check)
     def withConnection[A](block: Connection => A): A = {
       dbConfig.db.withSession { session =>


### PR DESCRIPTION
Hi,

I used the `leakDetectionThreshold` parameter of Hikari to debug this one. Here is the output : 

```
2015-07-29 11:13:07,158 - WARN  com.zaxxer.hikari.pool.LeakTask: Connection leak detection triggered for connection org.postgresql.jdbc4.Jdbc4Connection@4a452d73, stack trace follows
java.lang.Exception: Apparent connection leak detected
	at slick.jdbc.HikariCPJdbcDataSource.createConnection(JdbcDataSource.scala:131) ~[slick_2.11-3.0.0.jar:na]
	at slick.jdbc.JdbcBackend$BaseSession.conn$lzycompute(JdbcBackend.scala:394) ~[slick_2.11-3.0.0.jar:na]
	at slick.jdbc.JdbcBackend$BaseSession.conn(JdbcBackend.scala:394) ~[slick_2.11-3.0.0.jar:na]
	at slick.jdbc.JdbcBackend$BaseSession.metaData$lzycompute(JdbcBackend.scala:395) ~[slick_2.11-3.0.0.jar:na]
	at slick.jdbc.JdbcBackend$BaseSession.metaData(JdbcBackend.scala:395) ~[slick_2.11-3.0.0.jar:na]
	at play.api.db.slick.evolutions.internal.DBApiAdapter$DatabaseAdapter.url(DBApiAdapter.scala:51) ~[play-slick-evolutions_2.11-1.0.0.jar:1.0.0]
	at play.api.db.evolutions.DatabaseEvolutions.createPlayEvolutionsTable$1(EvolutionsApi.scala:237) ~[play-jdbc-evolutions_2.11-2.4.0.jar:2.4.0]
```

