### PR TITLE
HikariCP version matches the one used in Slick 3.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Version {
   val play = _root_.play.core.PlayVersion.current
 
   val slick        = "3.0.1"
-  val hikariCP     = "2.3.8"
+  val hikariCP     = "2.3.7"
   val h2           = "1.4.187"
 }
 
@@ -33,6 +33,6 @@ object Library {
   val playJdbcEvolutions  = "com.typesafe.play"        %% "play-jdbc-evolutions"     % Version.play
   val playSpecs2          = "com.typesafe.play"        %% "play-specs2"              % Version.play
   val slick               = "com.typesafe.slick"       %% "slick"                    % Version.slick
-  val hikariCP            = "com.zaxxer"               %  "HikariCP"                 % Version.hikariCP
+  val hikariCP            = "com.zaxxer"               %  "HikariCP-java6"           % Version.hikariCP
   val h2                  = "com.h2database"           %  "h2"                       % Version.h2
 }


### PR DESCRIPTION
Because HikariCP doesn't yet guarantee binary compatibility of its releases (see
brettwooldridge/HikariCP#360), it's safer that play-slick uses the exact same
version of HikariCP used to compile Slick 3.0 (which is currently v2.3.7).

Furthermore, Slick 3 uses the HikariCP-java6 binaries, while in play-slick we
were using the HikariCP binaries for Java8. While this shouldn't create problems
(because the two releases are built from the same tag - see
https://groups.google.com/forum/#!topic/hikari-cp/MqCtC4RQdeA), it's once again
safer to use the same binaries used by Slick.

\cc @szeiger 