### PR TITLE
Use a larger connection timeout for iteratee-sample tests. Fix #297

### DIFF
--- a/samples/iteratee/build.sbt
+++ b/samples/iteratee/build.sbt
@@ -3,3 +3,5 @@ name := "iteratee-sample"
 PlayKeys.playOmnidoc := false
 
 libraryDependencies += "com.typesafe.play" %% "play-streams-experimental" % Version.play
+
+javaOptions in Test += "-Dconfig.file=conf/application-test.conf"

--- a/samples/iteratee/conf/application-test.conf
+++ b/samples/iteratee/conf/application-test.conf
@@ -1,0 +1,3 @@
+include "application.conf"
+
+slick.dbs.default.connectionTimeout=30 seconds


### PR DESCRIPTION
This is an attempt to fix the spurious test failure happening when
running the iteratee-sample IntegrationSpec test.