### PR TITLE
Correctly reading the database's url from a datasource's config. Fix #324

### DIFF
--- a/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala
+++ b/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala
@@ -48,7 +48,7 @@ class SlickApiSpec extends Specification {
   "SlickApi.dbConfigs" should {
     "return all DatabaseConfig instances for a valid configuration" in {
       import SUTWithGoodConfig._
-      api.dbConfigs[BasicProfile] must have size(3)
+      api.dbConfigs[BasicProfile] must have size(4)
     }
     "throw if a database name doesn't exist in the config" in {
       import SUTWithBadConfig._

--- a/src/core/src/test/scala/play/api/db/slick/TestData.scala
+++ b/src/core/src/test/scala/play/api/db/slick/TestData.scala
@@ -3,6 +3,15 @@ package play.api.db.slick
 import play.api.Configuration
 
 object TestData {
+  private lazy val h2DatasourceConfig: Configuration = Configuration.from(
+    Map(
+      "slick.dbs.h2datasource.driver" -> "slick.driver.H2Driver$",
+      "slick.dbs.h2datasource.db.dataSourceClass" -> "slick.jdbc.DatabaseUrlDataSource",
+      "slick.dbs.h2datasource.db.properties.driver" -> "org.h2.Driver",
+      "slick.dbs.h2datasource.db.properties.url" -> "jdbc:h2:mem:"
+    )
+  )
+
   val configuration: Configuration = Configuration.from(
     Map(
       "slick.dbs.somedb.driver" -> "slick.driver.H2Driver$",
@@ -14,7 +23,7 @@ object TestData {
 
       "slick.dbs.jdbc-driver-not-recognized.driver" -> "slick.driver.MySQLDriver$",
       "slick.dbs.jdbc-driver-not-recognized.db.driver" -> "play.api.db.slick.SomeDummyDriver"
-  ))
+  )) ++ h2DatasourceConfig
 
   val badConfiguration: Configuration = configuration ++ Configuration.from(
     Map("slick.dbs.missing-slick-driver.db.driver" -> "play.api.db.slick.SomeDummyDriver"))

--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
@@ -1,6 +1,7 @@
 package play.api.db.slick.evolutions.internal
 
 import java.sql.Connection
+import java.sql.SQLException
 
 import javax.inject.Inject
 import javax.sql.DataSource
@@ -51,7 +52,7 @@ private[evolutions] object DBApiAdapter {
       }
     }
 
-    lazy val url: String = dbConfig.config.getString("db.url")
+    lazy val url: String = withConnection(_.getMetaData().getURL())
 
     def getConnection(): Connection = dbConfig.db.source.createConnection()
 
@@ -65,7 +66,7 @@ private[evolutions] object DBApiAdapter {
       val conn = getConnection()
       try block(conn)
       finally {
-        try conn.close() catch { case _: java.sql.SQLException => }
+        try conn.close() catch { case _: SQLException => }
       }
     }
 

--- a/src/evolutions/src/test/scala/play/api/db/slick/evolutions/DBApiAdapterSpec.scala
+++ b/src/evolutions/src/test/scala/play/api/db/slick/evolutions/DBApiAdapterSpec.scala
@@ -54,8 +54,12 @@ class DBApiAdapterSpec extends Specification {
     }
     
     "url" should {
-      "return the value set in the config" in {
+      "return the value set in the config for the jdbc url" in {
         db.url must_== TestData.configuration.getString(s"slick.dbs.${dbName}.db.url").get
+      }
+      "return the value set in the config for the datasource url" in {
+        val h2DatasourceDb = api.database("h2datasource")
+        h2DatasourceDb.url must_== TestData.configuration.getString(s"slick.dbs.h2datasource.db.properties.url").get
       }
     }
   }


### PR DESCRIPTION
In play-slick 1.0.x we were using the connection's metadata to retrieve the
database's url. In play-slick 1.1.x we have tried to use the Slick database's
config, but the implementation didn't consider datasource's config, as the
stacktrace in the related ticket demonstrates.

The fix simply consisted in reintroducing the former, play-slick 1.0.x,
behavior, as it seemed to have been working just fine so far.