### PR TITLE
Setting master version to 1.1.0-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
As it will take a while before Slick 3.2 M1 will be published, separating
development for play-slick 1.1.x and 1.2.x is not worth at the moment. Hence,
this commit changes the master version back to 1.1.0-SNAPSHOT and we can remove
the 1.1.x branch.