### PR TITLE
Bumped Scala version to 2.11.7 in sample projects. Fix #332

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ def sampleProject(name: String) =
       concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
     ).settings(libraryDependencies += "com.h2database" % "h2" % "1.4.187")
     .settings(javaOptions in Test += "-Dslick.dbs.default.connectionTimeout=30 seconds")
+    .settings(scalaVersion := "2.11.7")
     .enablePlugins(PlayScala)
     .dependsOn(`play-slick`)
     .dependsOn(`play-slick-evolutions`)


### PR DESCRIPTION
When updating interplay to 1.1.0 (see 7655ac1cb4ef561bae7659e1d6a17865d790ef0c),
I've forgot to bump the Scala version to 2.11.7 in the project's sample
factory.