### PR TITLE
Remove deprecation from guide code

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/slick/code/DI.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/DI.scala
@@ -12,7 +12,7 @@ import play.api.mvc._
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 import UsersSchema._
 
@@ -21,7 +21,7 @@ class Application @Inject()(dbConfigProvider: DatabaseConfigProvider) extends Co
   val dbConfig = dbConfigProvider.get[JdbcProfile]
   //#di-database-config
 
-  import dbConfig.driver.api._
+  import dbConfig.profile.api._
 
   def index(name: String) = Action.async { implicit request =>
     val resultingUsers: Future[Seq[User]] = dbConfig.db.run(Users.filter(_.name === name).result)

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
@@ -11,7 +11,7 @@ import play.api.mvc._
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 import UsersSchema._
 
@@ -21,7 +21,7 @@ object Application extends Controller {
   //#global-lookup-database-config
 
   //#driver-import
-  import dbConfig.driver.api._
+  import dbConfig.profile.api._
   //#driver-import
 
   //#action-with-db

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/UsersSchema.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/UsersSchema.scala
@@ -3,7 +3,7 @@
  */
 package scalaguide.slick
 
-import slick.driver.H2Driver.api._
+import slick.jdbc.H2Profile.api._
 
 object UsersSchema {
 
@@ -12,7 +12,7 @@ object UsersSchema {
   class UsersTable(tag: Tag) extends Table[User](tag, "USER") {
     def name = column[String]("name", O.PrimaryKey)
     def surname = column[String]("surname")
-    def * = (name, surname) <> (User.tupled, User.unapply _)
+    def * = (name, surname) <> (User.tupled, User.unapply)
   }
 
   val Users = TableQuery[UsersTable]


### PR DESCRIPTION
This is a follow up for #370. It removes deprecated api usage from documentation code.