### PR TITLE
Updated documentation for play-slick usage

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
+++ b/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
@@ -106,7 +106,7 @@ If something isn't properly configured, you will be notified in your browser:
 
 ## Usage
 
-After having properly configured a Slick database, you can obtain a `DatabaseConfig` (which is a Slick type bundling a database and driver) in two different ways. Either by using dependency injection, or through a global lookup via the `DatabaseConfigProvider` singleton.
+After having properly configured a Slick database, you can obtain a `DatabaseConfig` (which is a Slick type bundling a database and driver) in two different ways: either by using dependency injection and extending the trait `HasDatabaseConfigProvider[JdbcProfile]`, or through a global lookup via the `DatabaseConfigProvider` singleton and a reference to the application provider via `Provider[Application]` using dependency injection.
 
 > Note: A Slick database instance manages a thread pool and a connection pool. In general, you should not need to shut down a database explicitly in your code (by calling its `close` method), as the Play Slick module takes care of this already.
 
@@ -122,11 +122,13 @@ Injecting a `DatabaseConfig` instance for a different database is also easy. Sim
 
 Of course, you should replace the string `"<db-name>"` with the name of the database's configuration you want to use.
 
+> Note: To access the database object, you need only call the function `db` with this method, as it is passed from the trait. You do not need to reference the dbConfigProvider constructor parameter.
+
 For a full example, have a look at [this sample project](https://github.com/playframework/play-slick/tree/master/samples/basic).
 
 ### DatabaseConfig via Global Lookup
 
-Here is an example of how to lookup a `DatabaseConfig` instance for the default database (i.e., the database named `default` in your configuration):
+Here is an example of how to lookup a `DatabaseConfig` instance for the default database (i.e., the database named `default` in your configuration) from the `DatabaseConfigProvider` singleton and a `provider: Provider[Application]` reference:
 
 @[global-lookup-database-config](code/GlobalLookup.scala)
 

--- a/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
+++ b/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
@@ -106,7 +106,7 @@ If something isn't properly configured, you will be notified in your browser:
 
 ## Usage
 
-After having properly configured a Slick database, you can obtain a `DatabaseConfig` (which is a Slick type bundling a database and driver) in two different ways: either by using dependency injection and extending the trait `HasDatabaseConfigProvider[JdbcProfile]`, or through a global lookup via the `DatabaseConfigProvider` singleton and a reference to the application provider via `Provider[Application]` using dependency injection.
+After having properly configured a Slick database, you can obtain a `DatabaseConfig` (which is a Slick type bundling a database and driver) in two different ways: either by using dependency injection and extending the trait `HasDatabaseConfigProvider[JdbcProfile]`, or through a global lookup via the `DatabaseConfigProvider` singleton and a reference to the application via `Application` using dependency injection.
 
 > Note: A Slick database instance manages a thread pool and a connection pool. In general, you should not need to shut down a database explicitly in your code (by calling its `close` method), as the Play Slick module takes care of this already.
 
@@ -128,7 +128,7 @@ For a full example, have a look at [this sample project](https://github.com/play
 
 ### DatabaseConfig via Global Lookup
 
-Here is an example of how to lookup a `DatabaseConfig` instance for the default database (i.e., the database named `default` in your configuration) from the `DatabaseConfigProvider` singleton and a `provider: Provider[Application]` reference:
+Here is an example of how to lookup a `DatabaseConfig` instance for the default database (i.e., the database named `default` in your configuration) from the `DatabaseConfigProvider` singleton and an `application: Application` reference:
 
 @[global-lookup-database-config](code/GlobalLookup.scala)
 

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/DI.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/DI.scala
@@ -9,10 +9,10 @@ import javax.inject.Inject
 import scala.concurrent.Future
 
 import play.api.mvc._
-import play.api.db.slick.DatabaseConfigProvider
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-import slick.jdbc.JdbcProfile
+import slick.driver.JdbcProfile
 
 import UsersSchema._
 

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/DI.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/DI.scala
@@ -17,20 +17,19 @@ import slick.jdbc.JdbcProfile
 import UsersSchema._
 
 //#di-database-config
-class Application @Inject() (dbConfigProvider: DatabaseConfigProvider) extends Controller {
-  val dbConfig = dbConfigProvider.get[JdbcProfile]
+class Application @Inject() (protected val dbConfigProvider: DatabaseConfigProvider) extends Controller with HasDatabaseConfigProvider[JdbcProfile] {
   //#di-database-config
 
-  import dbConfig.profile.api._
+  import driver.api._
 
   def index(name: String) = Action.async { implicit request =>
-    val resultingUsers: Future[Seq[User]] = dbConfig.db.run(Users.filter(_.name === name).result)
+    val resultingUsers: Future[Seq[User]] = db.run(Users.filter(_.name === name).result)
     resultingUsers.map(users => Ok(views.html.index(users)))
   }
 }
 
 import play.db.NamedDatabase
 //#named-di-database-config
-class Application2 @Inject() (@NamedDatabase("<db-name>") dbConfigProvider: DatabaseConfigProvider) extends Controller {
+class Application2 @Inject() (@NamedDatabase("<db-name>") protected val dbConfigProvider: DatabaseConfigProvider) extends Controller with HasDatabaseConfigProvider[JdbcProfile] {
   //#named-di-database-config
 }

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
@@ -6,7 +6,7 @@ package global
 
 import scala.concurrent.Future
 
-import javax.inject.{Inject, Provider}
+import javax.inject.Inject
 import play.api.Application
 import play.api.mvc._
 import play.api.db.slick.DatabaseConfigProvider
@@ -16,9 +16,9 @@ import slick.driver.JdbcProfile
 
 import UsersSchema._
 
-class Application1 @Inject()(provider: Provider[Application]) extends Controller {
+class Application1 @Inject()(application: Application) extends Controller {
   //#global-lookup-database-config
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](provider.get())
+  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](application)
   //#global-lookup-database-config
 
   //#driver-import
@@ -33,8 +33,8 @@ class Application1 @Inject()(provider: Provider[Application]) extends Controller
   //#action-with-db
 }
 
-class Application2 @Inject()(provider: Provider[Application]) extends Controller {
+class Application2 @Inject()(application: Application) extends Controller {
   //#named-global-lookup-database-config
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile]("<db-name>")(provider.get())
+  val dbConfig = DatabaseConfigProvider.get[JdbcProfile]("<db-name>")(application)
   //#named-global-lookup-database-config
 }

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
@@ -6,7 +6,8 @@ package global
 
 import scala.concurrent.Future
 
-import play.api.Play
+import javax.inject.{Inject, Provider}
+import play.api.Application
 import play.api.mvc._
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -15,13 +16,13 @@ import slick.jdbc.JdbcProfile
 
 import UsersSchema._
 
-object Application extends Controller {
+class Application1 @Inject()(provider: Provider[Application]) extends Controller {
   //#global-lookup-database-config
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](provider.get())
   //#global-lookup-database-config
 
   //#driver-import
-  import dbConfig.profile.api._
+  import dbConfig.driver.api._
   //#driver-import
 
   //#action-with-db
@@ -32,8 +33,8 @@ object Application extends Controller {
   //#action-with-db
 }
 
-object Application2 extends Controller {
+class Application2 @Inject()(provider: Provider[Application]) extends Controller {
   //#named-global-lookup-database-config
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile]("<db-name>")(Play.current)
+  val dbConfig = DatabaseConfigProvider.get[JdbcProfile]("<db-name>")(provider.get())
   //#named-global-lookup-database-config
 }

--- a/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
+++ b/docs/manual/working/scalaGuide/main/sql/slick/code/GlobalLookup.scala
@@ -12,7 +12,7 @@ import play.api.mvc._
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-import slick.jdbc.JdbcProfile
+import slick.driver.JdbcProfile
 
 import UsersSchema._
 


### PR DESCRIPTION
References to Play.current are currently deprecated, and in play-slick 2.0.x referencing slick 3.1, JdbcProfile was moved to the slick.driver package from slick.jdbc