### PR TITLE
slickApi must be abstract in SlickEvolutionsComponents

### DIFF
--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/EvolutionsModule.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/EvolutionsModule.scala
@@ -22,7 +22,7 @@ class EvolutionsModule extends Module {
 trait SlickEvolutionsComponents {
   @deprecated("Use slickApi instead", "3.0.0")
   def api: SlickApi
-  def slickApi: SlickApi = api
+  def slickApi: SlickApi
 
   lazy val dbApi: DBApi = SlickDBApi(slickApi)
 }

--- a/src/evolutions/src/test/scala/play/api/db/slick/evolutions/EvolutionsModuleSpec.scala
+++ b/src/evolutions/src/test/scala/play/api/db/slick/evolutions/EvolutionsModuleSpec.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.Specification
 import play.api.Configuration
 import play.api.Environment
 import play.api.db.DBApi
-import play.api.db.slick.{ DefaultSlickApi, SlickApi, SlickComponents, TestData }
+import play.api.db.slick.{ SlickComponents, TestData }
 import play.api.db.slick.evolutions.internal.DBApiAdapter
 import play.api.inject.ApplicationLifecycle
 import play.api.inject.DefaultApplicationLifecycle
@@ -45,8 +45,6 @@ class EvolutionsModuleSpec extends Specification {
       override def configuration: Configuration = TestData.configuration
 
       override def executionContext: ExecutionContext = ExecutionContext.Implicits.global // using the global EC since this is test code
-
-      override lazy val slickApi: SlickApi = new DefaultSlickApi(environment, configuration, applicationLifecycle)(executionContext)
     }
 
     "bind DBApi to DBApiAdapter" in {


### PR DESCRIPTION
If I try to implement an application loader with components class for compile-time DI and want to mixin `SlickEvolutionsComponents` trait (together with `SlickComponents` which contains the actual implementation of `slickApi`) to it, I am getting the following compile error:
```
class Components inherits conflicting members:
[error]   lazy value slickApi in trait SlickComponents of type play.api.db.slick.SlickApi  and
[error]   method slickApi in trait SlickEvolutionsComponents of type => play.api.db.slick.SlickApi
[error] (Note: this can be resolved by declaring an override in class Components.)
[error] class Components(context: ApplicationLoader.Context)
```
A workaround for it is to override `slickApi` again in components class, but it's ugly:
```
override lazy val slickApi: SlickApi = super.slickApi
```
The issues is that `slickApi` is implemented in two different trait which is most likely not by design, but by mistake when renaming `api` to `slickApi` and deprecating old `api`.