### PR TITLE
Update to slick 3.2.1 -> propose play-slick plugin release of 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ For Play 2.5.x and Slick 3.2.x (Scala 2.11):
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-slick" % "2.1.0",
-  "com.typesafe.play" %% "play-slick-evolutions" % "2.1.0"
+  "com.typesafe.play" %% "play-slick" % "2.1.1",
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.1.1"
 )
 ```
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick        = "3.2.0"
+  val slick        = "3.2.1"
   val h2           = "1.4.193"
 }
 


### PR DESCRIPTION
slick 3.2.1 fixes race-condition using unpinned/flatMapped DBIOActions, leading to missing decreaseInUseCount calls and possible stall of ManagedBlockingArrayQueue
https://github.com/slick/slick/issues/1730