### PR TITLE
this field should be lazy to avoid early initialization problems.

### DIFF
--- a/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
+++ b/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
@@ -193,5 +193,5 @@ trait HasDatabaseConfig[P <: BasicProfile] {
 trait HasDatabaseConfigProvider[P <: BasicProfile] extends HasDatabaseConfig[P] {
   /** The provider of a Slick `DatabaseConfig` instance.*/
   protected val dbConfigProvider: DatabaseConfigProvider
-  override final protected val dbConfig: DatabaseConfig[P] = dbConfigProvider.get[P]
+  override final lazy protected val dbConfig: DatabaseConfig[P] = dbConfigProvider.get[P] // field is lazy to avoid early initializer problems.
 }


### PR DESCRIPTION
The filed `dbConfig` should be lazy to avoid early initialization problems.
In my particular case I have a class:

`class SomeDAO @Inject()(protected val dbConfigProvider: DatabaseConfigProvider) extends HasDatabaseConfigProvider[JdbcProfile] { ... }`

that needs to be mocked and the eager initialization makes the mock fail with a 

`java.lang.NullPointerException
	at play.api.db.slick.HasDatabaseConfigProvider$class.$init$(DatabaseConfigProvider.scala:196)`