### PR TITLE
Update docs to reflect latest Play+Slick version

### DIFF
--- a/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
+++ b/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
@@ -5,9 +5,9 @@ The Play Slick module makes [Slick](http://slick.typesafe.com/) a first-class ci
   - Integration of Slick into Play's application lifecycle.
   - Support for [[Play database evolutions|Evolutions]].
 
-Play Slick currently supports Slick 3.1 with Play 2.5, for Scala 2.11.
+Play Slick currently supports Slick 3.2 with Play 2.6, for Scala 2.12 and Scala 2.11.
 
-> **Note**: This guide assumes you already know both Play 2.5 and Slick 3.1.
+> **Note**: This guide assumes you already know both Play 2.6 and Slick 3.2.
 
 ### Getting Help
 


### PR DESCRIPTION
Since this page appears on https://www.playframework.com/documentation/2.6.x/PlaySlick it is a tad confusing when it says it only supports Play 2.5 and Slick 3.1.