### PR TITLE
Deleted deprecated SlickComponents.api field

### DIFF
--- a/src/core/src/main/scala/play/api/db/slick/SlickModule.scala
+++ b/src/core/src/main/scala/play/api/db/slick/SlickModule.scala
@@ -65,7 +65,5 @@ trait SlickComponents {
   def applicationLifecycle: ApplicationLifecycle
   def executionContext: ExecutionContext
 
-  @deprecated("Use slickApi instead", "3.0.0")
-  lazy val api: SlickApi = slickApi
   lazy val slickApi: SlickApi = new DefaultSlickApi(environment, configuration, applicationLifecycle)(executionContext)
 }


### PR DESCRIPTION
This field make SlickComponents incompatible with macwire, there's no way to keep it around without providing a bad user experience for people using compile time dependency injection with macwire.

See #422 for a more complete discussion on why this should be deleted and not kept around.