### PR TITLE
Delete deprecated SlickComponents.api field

### DIFF
--- a/src/core/src/main/scala/play/api/db/slick/SlickModule.scala
+++ b/src/core/src/main/scala/play/api/db/slick/SlickModule.scala
@@ -65,7 +65,5 @@ trait SlickComponents {
   def applicationLifecycle: ApplicationLifecycle
   def executionContext: ExecutionContext
 
-  @deprecated("Use slickApi instead", "3.0.0")
-  lazy val api: SlickApi = slickApi
   lazy val slickApi: SlickApi = new DefaultSlickApi(environment, configuration, applicationLifecycle)(executionContext)
 }

--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/EvolutionsModule.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/EvolutionsModule.scala
@@ -20,8 +20,6 @@ class EvolutionsModule extends Module {
  * Helper to provide Slick implementation of DBApi.
  */
 trait SlickEvolutionsComponents {
-  @deprecated("Use slickApi instead", "3.0.0")
-  def api: SlickApi
   def slickApi: SlickApi
 
   lazy val dbApi: DBApi = SlickDBApi(slickApi)


### PR DESCRIPTION
Fixes #422, closes #423 

This field make SlickComponents incompatible with macwire, there's no
way to keep it around without providing a bad user experience for people
using compile time dependency injection with macwire.