### PR TITLE
Add latest scala 2.12.7 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.12.6
+- 2.12.7
 - 2.11.12
 jdk: oraclejdk8
 sudo: false


### PR DESCRIPTION
A lot of people will instantly migrate to Scala 2.12.7 because it has a lot of performance improvements.

More info: https://github.com/scala/scala/releases/tag/v2.12.7