### PR TITLE
Upgrade slick 3.2.{1 => 3}

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick        = "3.2.1"
+  val slick        = "3.2.3"
   val h2           = "1.4.196"
 }
 


### PR DESCRIPTION
3.2.2 and 3.2.3 include several bugfixes, including for concurrency
bugs.

http://slick.lightbend.com/news/2018/03/06/slick-3.2.2-released.html

http://slick.lightbend.com/news/2018/03/23/slick-3.2.3-released.html