### PR TITLE
Remove wiki reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Note that the `+` next to a version means that the specified version and later t
 
 The documentation for the latest release is available [here](https://www.playframework.com/documentation/latest/PlaySlick).
 
-Documentation for v0.8 is available in the project's [wiki](https://github.com/playframework/play-slick/wiki).
-
 ## Copyright
 
 Copyright (C) 2009-2017 Lightbend Inc. (https://www.lightbend.com).


### PR DESCRIPTION
It seems this github project no longer has a wiki, so any links are fwd to the github project homepage