### PR TITLE
remove invalid stripMargin

### DIFF
--- a/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
+++ b/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
@@ -92,7 +92,7 @@ object DatabaseConfigProvider {
    */
   @throws(classOf[IllegalArgumentException])
   @deprecated(
-    "Use DatabaseConfigProvider#get[P] or SlickApi#dbConfig[P](\"default\") on injected instances".stripMargin,
+    "Use DatabaseConfigProvider#get[P] or SlickApi#dbConfig[P](\"default\") on injected instances",
     "3.0.0"
   )
   def get[P <: BasicProfile](implicit app: Application): DatabaseConfig[P] =


### PR DESCRIPTION
```
Welcome to Scala 2.13.6 (OpenJDK 64-Bit Server VM, Java 1.8.0_292).
Type in expressions for evaluation. Or try :help.

scala> @deprecated("a".stripMargin, "b") def x = 2
                       ^
       error: annotation argument needs to be a constant; found: scala.Predef.augmentString("a").stripMargin
```

```
Welcome to Scala 2.12.14 (OpenJDK 64-Bit Server VM, Java 1.8.0_292).
Type in expressions for evaluation. Or try :help.

scala> @deprecated("a".stripMargin, "b") def x = 2
x: Int
```