### PR TITLE
fix `Auto-application` warnings

### DIFF
--- a/samples/basic/app/controllers/Application.scala
+++ b/samples/basic/app/controllers/Application.scala
@@ -33,12 +33,12 @@ class Application @Inject() (
       "color" -> text())(Dog.apply)(Dog.unapply))
 
   def insertCat = Action.async { implicit request =>
-    val cat: Cat = catForm.bindFromRequest.get
+    val cat: Cat = catForm.bindFromRequest().get
     catDao.insert(cat).map(_ => Redirect(routes.Application.index))
   }
 
   def insertDog = Action.async { implicit request =>
-    val dog: Dog = dogForm.bindFromRequest.get
+    val dog: Dog = dogForm.bindFromRequest().get
     dogDao.insert(dog).map(_ => Redirect(routes.Application.index))
   }
 }

--- a/samples/computer-database/app/controllers/Application.scala
+++ b/samples/computer-database/app/controllers/Application.scala
@@ -73,7 +73,7 @@ class Application @Inject() (
    * @param id Id of the computer to edit
    */
   def update(id: Long) = Action.async { implicit rs =>
-    computerForm.bindFromRequest.fold(
+    computerForm.bindFromRequest().fold(
       formWithErrors => companiesDao.options().map(options => BadRequest(html.editForm(id, formWithErrors, options))),
       computer => {
         for {
@@ -89,7 +89,7 @@ class Application @Inject() (
 
   /** Handle the 'new computer form' submission. */
   def save = Action.async { implicit rs =>
-    computerForm.bindFromRequest.fold(
+    computerForm.bindFromRequest().fold(
       formWithErrors => companiesDao.options().map(options => BadRequest(html.createForm(formWithErrors, options))),
       computer => {
         for {

--- a/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala
+++ b/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala
@@ -48,15 +48,15 @@ class SlickApiSpec extends Specification {
   "SlickApi.dbConfigs" should {
     "return all DatabaseConfig instances for a valid configuration" in {
       import SUTWithGoodConfig._
-      api.dbConfigs[BasicProfile] must have size 4
+      api.dbConfigs[BasicProfile]() must have size 4
     }
     "throw if a database name doesn't exist in the config" in {
       import SUTWithBadConfig._
-      api.dbConfigs[BasicProfile] must throwA[PlayException]
+      api.dbConfigs[BasicProfile]() must throwA[PlayException]
     }
     "throw if a database config doesn't define a Slick profile" in {
       import SUTWithBadConfig._
-      api.dbConfigs[BasicProfile] must throwA[PlayException]
+      api.dbConfigs[BasicProfile]() must throwA[PlayException]
     }
   }
 }

--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/internal/DBApiAdapter.scala
@@ -26,7 +26,7 @@ private[evolutions] class DBApiAdapter @Inject() (slickApi: SlickApi) extends DB
     }
     .toMap
 
-  override def databases: Seq[PlayDatabase] = databasesByName.values.toSeq
+  override def databases(): Seq[PlayDatabase] = databasesByName.values.toSeq
 
   def database(name: String): PlayDatabase =
     databasesByName.getOrElse(DbName(name), throw new IllegalArgumentException(s"Could not find database for $name"))


### PR DESCRIPTION
```
[warn] /home/travis/build/playframework/play-slick/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala:51:20: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method dbConfigs,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]       api.dbConfigs[BasicProfile] must have size 4
[warn]                    ^
[warn] /home/travis/build/playframework/play-slick/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala:55:20: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method dbConfigs,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]       api.dbConfigs[BasicProfile] must throwA[PlayException]
[warn]                    ^
[warn] /home/travis/build/playframework/play-slick/src/core/src/test/scala/play/api/db/slick/SlickApiSpec.scala:59:20: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method dbConfigs,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]       api.dbConfigs[BasicProfile] must throwA[PlayException]
[warn]                    ^
```

```
[warn] /home/travis/build/playframework/play-slick/samples/computer-database/app/controllers/Application.scala:76:18: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method bindFromRequest,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     computerForm.bindFromRequest.fold(
[warn]                  ^
[warn] /home/travis/build/playframework/play-slick/samples/computer-database/app/controllers/Application.scala:92:18: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method bindFromRequest,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     computerForm.bindFromRequest.fold(
[warn]                  ^
```

```
[warn] /home/travis/build/playframework/play-slick/samples/basic/app/controllers/Application.scala:36:28: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method bindFromRequest,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     val cat: Cat = catForm.bindFromRequest.get
[warn]                            ^
[warn] /home/travis/build/playframework/play-slick/samples/basic/app/controllers/Application.scala:41:28: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method bindFromRequest,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     val dog: Dog = dogForm.bindFromRequest.get
[warn]                            ^
```