### PR TITLE
@deprecated annotation needs to be constant

### DIFF
--- a/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
+++ b/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
@@ -92,7 +92,7 @@ object DatabaseConfigProvider {
    */
   @throws(classOf[IllegalArgumentException])
   @deprecated(
-    "Use DatabaseConfigProvider#get[P] or SlickApi#dbConfig[P](\"default\") on injected instances".stripMargin,
+    "Use DatabaseConfigProvider#get[P] or SlickApi#dbConfig[P](\"default\") on injected instances",
     "3.0.0"
   )
   def get[P <: BasicProfile](implicit app: Application): DatabaseConfig[P] =


### PR DESCRIPTION
Otherwise scaladoc will complain in Scala 2.13.6
See https://github.com/scala/scala/pull/9336

Happened to me when I wanted to bump to Scala 2.13.7 in omnidoc:
https://github.com/playframework/omnidoc/pull/186
```
[error] /home/travis/build/playframework/omnidoc/target/scala-2.13/omnidoc/sources/com.typesafe.play-play-slick_2.13-5.0.0/play/api/db/slick/DatabaseConfigProvider.scala:95:100: annotation argument needs to be a constant; found: scala.Predef.augmentString("Use DatabaseConfigProvider#get[P] or SlickApi#dbConfig[P](\"default\") on injected instances").stripMargin
[error]     "Use DatabaseConfigProvider#get[P] or SlickApi#dbConfig[P](\"default\") on injected instances".stripMargin,
[error]                                                                                                    ^
[warn] one warning found
[error] one error found
[error] (Omnidoc / scaladoc) Scaladoc generation failed
```
https://app.travis-ci.com/github/playframework/omnidoc/jobs/554426274#L1281