### PR TITLE
Rename master branch to main

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-# This file was originally copied from https://github.com/playframework/playframework/blob/master/.scalafmt.conf
+# This file was originally copied from https://github.com/playframework/playframework/blob/main/.scalafmt.conf
 version = 3.4.2
 runner.dialect = scala213
 align.preset = more

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,13 @@ Before making a contribution, it is important to make sure that the change you w
         * Java APIs should go to `framework/play/src/main/java`, package structure is `play.myapipackage.xxxx`
         * Scala APIs should go to `framework/play/src/main/scala`, where the package structure is `play.api.myapipackage`
         * Features are forever, always think about whether a new feature really belongs to the core framework or if it should be implemented as a module
-        * Code must conform to standard style guidelines and pass all tests (see [validatePullRequest](https://github.com/playframework/playframework/blob/master/framework/validatePullRequest))
+        * Code must conform to standard style guidelines and pass all tests (see [validatePullRequest](https://github.com/playframework/playframework/blob/main/framework/validatePullRequest))
     6. New files must:
         * Have a Typesafe copyright header in the style of ``Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>``.
         * Not use ``@author`` tags since it does not encourage [Collective Code Ownership](http://www.extremeprogramming.org/rules/collective.html).
 3. Ensure that your commits are squashed.  See [working with git](https://playframework.com/documentation/latest/WorkingWithGit) for more information.
 4. Submit a pull request.
 
-If the pull request does not meet the above requirements then the code should **not** be merged into master, or even reviewed - regardless of how good or important it is. No exceptions.
+If the pull request does not meet the above requirements then the code should **not** be merged into main, or even reviewed - regardless of how good or important it is. No exceptions.
 
 The pull request will be reviewed according to the [implementation decision process](https://playframework.com/community-process#Implementation-decisions).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Play Slick
 
-[![Build Status](https://travis-ci.org/playframework/play-slick.png?branch=master)](https://travis-ci.org/playframework/play-slick) [![codecov.io](https://codecov.io/github/playframework/play-slick/coverage.svg?branch=master)](https://codecov.io/github/playframework/play-slick?branch=master)
+[![Build Status](https://travis-ci.org/playframework/play-slick.png?branch=main)](https://travis-ci.org/playframework/play-slick) [![codecov.io](https://codecov.io/github/playframework/play-slick/coverage.svg?branch=main)](https://codecov.io/github/playframework/play-slick?branch=main)
 
 The Play Slick module makes [Slick] a first-class citizen of [Play]. It consists of two features:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,8 +16,8 @@ Releasing a new version of play-slick is truly simple.
 That will start the build. The output should be similar to
 
 ```shell
-play ▶ [] ~/deploy$ ./release --project play-slick --branch master --tag 5.0.0
-This will release play-slick from branch master using JDK8, continue? [y/n] y
+play ▶ [] ~/deploy$ ./release --project play-slick --branch main --tag 5.0.0
+This will release play-slick from branch main using JDK8, continue? [y/n] y
 java version "1.8.0_31"
 ...
 ```
@@ -33,7 +33,7 @@ Once the binaries are successfully deployed, you will be prompted if you wish to
 [info] Setting version to '1.0.2-SNAPSHOT'.
 [info] Reapplying settings...
 [info] Set current project to play-slick-root (in build file:/home/play/deploy/play-slick/)
-[info] [master fa73a4f] Setting version to 1.0.2-SNAPSHOT
+[info] [main fa73a4f] Setting version to 1.0.2-SNAPSHOT
 [info]  1 file changed, 1 insertion(+), 1 deletion(-)
 Push changes to the remote repository (y/n)? [y]
 ```

--- a/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
+++ b/docs/manual/working/scalaGuide/main/sql/slick/PlaySlick.md
@@ -74,7 +74,7 @@ slick.dbs.default.db.dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
 slick.dbs.default.db.properties.driver = "org.postgresql.Driver"
 ```
 
-On some platforms, such as Heroku, you may [substitute](https://github.com/lightbend/config/blob/master/HOCON.md#substitution-fallback-to-environment-variables) the `JDBC_DATABASE_URL` environment variable, which is in the format `jdbc:vendor://host:port/db?args`, if it is available. For example:
+On some platforms, such as Heroku, you may [substitute](https://github.com/lightbend/config/blob/main/HOCON.md#substitution-fallback-to-environment-variables) the `JDBC_DATABASE_URL` environment variable, which is in the format `jdbc:vendor://host:port/db?args`, if it is available. For example:
 
 ```conf
 slick.dbs.default.profile="slick.jdbc.PostgresProfile$"


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```