### PR TITLE
Make dbConfig lazy to fix Scala 3 error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,14 +21,7 @@ lazy val commonSettings = Seq(
   scalacOptions ~= (_.filterNot(_ == "-Xfatal-warnings")),
   scalaVersion       := "2.13.11",               // scala213,
   crossScalaVersions := Seq("2.13.11", "3.3.0"), // scala213,
-  scalacOptions ++= {
-    if (scalaBinaryVersion.value == "3") {
-      Seq("-source:3.0-migration")
-    } else {
-      Nil
-    }
-  },
-  pomExtra := scala.xml.NodeSeq.Empty, // Can be removed when dropping interplay
+  pomExtra           := scala.xml.NodeSeq.Empty, // Can be removed when dropping interplay
   developers += Developer(
     "playframework",
     "The Play Framework Contributors",

--- a/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
+++ b/src/core/src/main/scala/play/api/db/slick/DatabaseConfigProvider.scala
@@ -152,7 +152,8 @@ object DatabaseConfigProvider {
 trait HasDatabaseConfig[P <: BasicProfile] {
 
   /** The Slick database configuration. */
-  protected val dbConfig: DatabaseConfig[P] // field is declared as a val because we want a stable identifier.
+  protected lazy val dbConfig: DatabaseConfig[P] =
+    ??? // field is declared as a val because we want a stable identifier. // TODO: Remove "= ???" when dropping Scala 2
   /** The Slick profile extracted from `dbConfig`. */
   protected final lazy val profile: P = dbConfig.profile // field is lazy to avoid early initializer problems.
   @deprecated("Use `profile` instead of `driver`", "2.1")


### PR DESCRIPTION
However since in Scala 2 "lazy values may not be abstract" we need to make it non-abstract with ???. Not the nicest thing to do, but ok...

The reason why I want to get rid of `-source:3.0-migration` is because https://github.com/playframework/omnidoc tries to generate scaladocs from play-slick and to do that for Scala 3 we need to actually compile the sources. Now when adding `-source:3.0-migration` in omnidoc a lot of other compiler errors occur from other classes (that are not part of play-slick)