### PR TITLE
Downgrade to Slick v3.4.1, so that Play v3 based version can be released

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
-      scala: 2.13.x, 3.x
+      scala: 2.13.x
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The Play Slick plugin supports several different versions of Play and Slick.
 
 | Plugin version | Play version | Slick version | Scala version        |
 |----------------|--------------|---------------|----------------------|
-| 6.0.x          | 3.0.0        | 3.5.0+        | 2.13.x/3.3.x         |
-| 5.2.x          | 2.9.0        | 3.5.0+        | 2.13.x/3.3.x         |
+| 6.0.x          | 3.0.0        | 3.4.1         | 2.13.x               |
+| 5.2.x          | 2.9.0        | 3.4.1         | 2.13.x               |
 | 5.1.x          | 2.8.16       | 3.4.1+        | 2.12.x/2.13.x        |
 | 5.0.x          | 2.8.x        | 3.3.2+        | 2.12.x/2.13.x        |
 | 4.0.2+         | 2.7.x        | 3.3.2+        | 2.11.x/2.12.x/2.13.x |

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val `play-slick-root` = (project in file("."))
 lazy val `play-slick` = (project in file("src/core"))
   .enablePlugins(Omnidoc, Playdoc, MimaPlugin)
   .configs(Docs)
-  .settings(libraryDependencies ++= Dependencies.core(CrossVersion.partialVersion(scalaVersion.value)))
+  .settings(libraryDependencies ++= Dependencies.core)
   .settings(mimaSettings)
   .settings(
     mimaBinaryIssueFilters ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ lazy val commonSettings = Seq(
   javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
   compile / javacOptions ++= Seq("--release", "11"),
   doc / javacOptions := Seq("-source", "11"),
-  scalaVersion       := "2.13.12",               // scala213,
-  crossScalaVersions := Seq("2.13.12", "3.3.1"), // scala213,
+  scalaVersion       := "2.13.12",
+  crossScalaVersions := Seq("2.13.12"),
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8") ++
     (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Seq("-Xsource:3")

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val `play-slick-root` = (project in file("."))
 lazy val `play-slick` = (project in file("src/core"))
   .enablePlugins(Omnidoc, Playdoc, MimaPlugin)
   .configs(Docs)
-  .settings(libraryDependencies ++= Dependencies.core)
+  .settings(libraryDependencies ++= Dependencies.core(CrossVersion.partialVersion(scalaVersion.value)))
   .settings(mimaSettings)
   .settings(
     mimaBinaryIssueFilters ++= Seq(
@@ -82,5 +82,8 @@ val previousVersion: Option[String] = Some("6.0.0-M1")
 ThisBuild / mimaFailOnNoPrevious := false
 
 def mimaSettings = Seq(
-  mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet
+  mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet,
+  mimaBinaryIssueFilters := Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.slick.HasDatabaseConfig.db")
+  )
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,10 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
-  val core = Seq(
-    Library.slick,
-    Library.slickHikariCP,
+  def core(scalaVersion: Option[(Long, Long)]) = (scalaVersion match {
+    case Some((3, _)) => Seq(Library.slick(Version.slick_35), Library.slickHikariCP(Version.slick_35))
+    case _            => Seq(Library.slick(Version.slick), Library.slickHikariCP(Version.slick))
+  }) ++ Seq(
     Library.playCore,
     Library.playJdbcApi,
     Library.playLogback % "test",
@@ -21,17 +22,18 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick = "3.4.1"
-  val h2    = "2.2.224"
+  val slick    = "3.4.1"
+  val slick_35 = "3.5.0-M4"
+  val h2       = "2.2.224"
 }
 
 object Library {
-  val playLogback        = "org.playframework"  %% "play-logback"         % Version.play
-  val playCore           = "org.playframework"  %% "play"                 % Version.play
-  val playJdbcApi        = "org.playframework"  %% "play-jdbc-api"        % Version.play
-  val playJdbcEvolutions = "org.playframework"  %% "play-jdbc-evolutions" % Version.play
-  val playSpecs2         = "org.playframework"  %% "play-specs2"          % Version.play
-  val slick              = "com.typesafe.slick" %% "slick"                % Version.slick
-  val slickHikariCP      = "com.typesafe.slick" %% "slick-hikaricp"       % Version.slick
-  val h2                 = "com.h2database"      % "h2"                   % Version.h2
+  val playLogback                    = "org.playframework"  %% "play-logback"         % Version.play
+  val playCore                       = "org.playframework"  %% "play"                 % Version.play
+  val playJdbcApi                    = "org.playframework"  %% "play-jdbc-api"        % Version.play
+  val playJdbcEvolutions             = "org.playframework"  %% "play-jdbc-evolutions" % Version.play
+  val playSpecs2                     = "org.playframework"  %% "play-specs2"          % Version.play
+  def slick(version: String)         = "com.typesafe.slick" %% "slick"                % version
+  def slickHikariCP(version: String) = "com.typesafe.slick" %% "slick-hikaricp"       % version
+  val h2                             = "com.h2database"      % "h2"                   % Version.h2
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick = "3.5.0-M4"
+  val slick = "3.4.1"
   val h2    = "2.2.224"
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,10 +1,9 @@
-import sbt.*
+import sbt._
 
 object Dependencies {
-  def core(scalaVersion: Option[(Long, Long)]) = (scalaVersion match {
-    case Some((3, _)) => Seq(Library.slick(Version.slick_35), Library.slickHikariCP(Version.slick_35))
-    case _            => Seq(Library.slick(Version.slick), Library.slickHikariCP(Version.slick))
-  }) ++ Seq(
+  val core = Seq(
+    Library.slick,
+    Library.slickHikariCP,
     Library.playCore,
     Library.playJdbcApi,
     Library.playLogback % "test",
@@ -22,18 +21,17 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick    = "3.4.1"
-  val slick_35 = "3.5.0-M4"
-  val h2       = "2.2.224"
+  val slick = "3.4.1"
+  val h2    = "2.2.224"
 }
 
 object Library {
-  val playLogback                    = "org.playframework"  %% "play-logback"         % Version.play
-  val playCore                       = "org.playframework"  %% "play"                 % Version.play
-  val playJdbcApi                    = "org.playframework"  %% "play-jdbc-api"        % Version.play
-  val playJdbcEvolutions             = "org.playframework"  %% "play-jdbc-evolutions" % Version.play
-  val playSpecs2                     = "org.playframework"  %% "play-specs2"          % Version.play
-  def slick(version: String)         = "com.typesafe.slick" %% "slick"                % version
-  def slickHikariCP(version: String) = "com.typesafe.slick" %% "slick-hikaricp"       % version
-  val h2                             = "com.h2database"      % "h2"                   % Version.h2
+  val playLogback        = "org.playframework"  %% "play-logback"         % Version.play
+  val playCore           = "org.playframework"  %% "play"                 % Version.play
+  val playJdbcApi        = "org.playframework"  %% "play-jdbc-api"        % Version.play
+  val playJdbcEvolutions = "org.playframework"  %% "play-jdbc-evolutions" % Version.play
+  val playSpecs2         = "org.playframework"  %% "play-specs2"          % Version.play
+  val slick              = "com.typesafe.slick" %% "slick"                % Version.slick
+  val slickHikariCP      = "com.typesafe.slick" %% "slick-hikaricp"       % Version.slick
+  val h2                 = "com.h2database"      % "h2"                   % Version.h2
 }


### PR DESCRIPTION
Play Slick v6.0 branch currently depends on 3.5.0-M4.
At the moment it seems difficult to estimate when Slick v3.5 will be released.
Play Slick v6 branch however contains very valuable changes, in particular support for Play v3.0 which would allow many users to transition to Play v3.0.
Please consider downgrading to Slick v3.4.1 and releasing v6.0 as is.