### PR TITLE
[5.2.x] Use stable slick 3.4 and drop out-of-the-box Scala 3 support for now

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
-      scala: 2.13.x, 3.x
+      scala: 2.13.x
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Play Slick plugin supports several different versions of Play and Slick.
 
 | Plugin version | Play version | Slick version | Scala version        |
 |----------------|--------------|---------------|----------------------|
-| 5.2.x          | 2.9.0        | 3.5.0+        | 2.13.x/3.3.x         |
+| 5.2.x          | 2.9.0        | 3.4.1         | 2.13.x               |
 | 5.1.x          | 2.8.16       | 3.4.1+        | 2.12.x/2.13.x        |
 | 5.0.x          | 2.8.x        | 3.3.2+        | 2.12.x/2.13.x        |
 | 4.0.2+         | 2.7.x        | 3.3.2+        | 2.11.x/2.12.x/2.13.x |

--- a/build.sbt
+++ b/build.sbt
@@ -73,5 +73,8 @@ val previousVersion: Option[String] = Some("5.2.0-RC1")
 ThisBuild / mimaFailOnNoPrevious := false
 
 def mimaSettings = Seq(
-  mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet
+  mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet,
+  mimaBinaryIssueFilters := Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.db.slick.HasDatabaseConfig.db")
+  )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 lazy val commonSettings = Seq(
   // Work around https://issues.scala-lang.org/browse/SI-9311
   scalacOptions ~= (_.filterNot(_ == "-Xfatal-warnings")),
-  scalaVersion       := "2.13.12",               // scala213,
-  crossScalaVersions := Seq("2.13.12", "3.3.1"), // scala213,
+  scalaVersion       := "2.13.12",
+  crossScalaVersions := Seq("2.13.12"),
   pomExtra           := scala.xml.NodeSeq.Empty, // Can be removed when dropping interplay
   developers += Developer(
     "playframework",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick = "3.5.0-M4"
+  val slick = "3.4.1"
   val h2    = "2.2.224"
 }
 


### PR DESCRIPTION
See
- #803