### PR TITLE
slick 3.5.0 final release + other dependency upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ lazy val commonSettings = Seq(
   javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
   compile / javacOptions ++= Seq("--release", "11"),
   doc / javacOptions := Seq("-source", "11"),
-  scalaVersion       := "2.13.12",
-  crossScalaVersions := Seq("2.13.12", "3.3.1"),
+  scalaVersion       := "2.13.13",
+  crossScalaVersions := Seq("2.13.13", "3.3.3"),
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8") ++
     (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Seq("-Xsource:3")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 object Version {
   val play = _root_.play.core.PlayVersion.current
 
-  val slick = "3.5.0-RC1"
+  val slick = "3.5.0"
   val h2    = "2.2.224"
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers ++= Resolver.sonatypeOssRepos(
   "snapshots"
 ) // used by deploy nightlies, which publish here & use -Dplay.version
 
-addSbtPlugin("org.playframework" % "sbt-plugin"           % sys.props.getOrElse("play.version", "3.0.1"))
-addSbtPlugin("org.playframework" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "3.0.1"))
+addSbtPlugin("org.playframework" % "sbt-plugin"           % sys.props.getOrElse("play.version", "3.0.2"))
+addSbtPlugin("org.playframework" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "3.0.2"))
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"    % "2.5.2")
 addSbtPlugin("com.typesafe"  % "sbt-mima-plugin" % "1.1.3")


### PR DESCRIPTION
- Fixes #826
- See https://github.com/slick/slick/releases/tag/v3.5.0