### PR TITLE
update `.scalafmt.conf`. enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -11,3 +11,10 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.newSyntax.control = false
+runner.dialectOverride {
+  allowSignificantIndentation = false
+  allowAsForImportRename = false
+  allowStarWildcardImport = false
+}

--- a/src/core/src/main/scala/play/api/db/slick/SlickApi.scala
+++ b/src/core/src/main/scala/play/api/db/slick/SlickApi.scala
@@ -108,7 +108,7 @@ object DefaultSlickApi {
       }
     }
 
-    private def registerDatabaseShutdownHook(dbConf: DatabaseConfig[_]): Unit = {
+    private def registerDatabaseShutdownHook(dbConf: DatabaseConfig[?]): Unit = {
       // clean-up when the application is stopped.
       lifecycle.addStopHook { () =>
         Future {

--- a/src/core/src/main/scala/play/api/db/slick/SlickModule.scala
+++ b/src/core/src/main/scala/play/api/db/slick/SlickModule.scala
@@ -31,7 +31,7 @@ object SlickModule {
 
 @Singleton
 final class SlickModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindings(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     val config  = configuration.underlying
     val dbKey   = config.getString(SlickModule.DbKeyConfig)
     val default = config.getString(SlickModule.DefaultDbName)
@@ -44,11 +44,11 @@ final class SlickModule extends Module {
     )
   }
 
-  def namedDatabaseConfigBindings(dbs: Set[String]): Seq[Binding[_]] = dbs.toList.map { db =>
+  def namedDatabaseConfigBindings(dbs: Set[String]): Seq[Binding[?]] = dbs.toList.map { db =>
     bindNamed(db).to(new NamedDatabaseConfigProvider(db))
   }
 
-  def defaultDatabaseConfigBinding(default: String, dbs: Set[String]): Seq[Binding[_]] =
+  def defaultDatabaseConfigBinding(default: String, dbs: Set[String]): Seq[Binding[?]] =
     if (dbs.contains(default)) Seq(bind[DatabaseConfigProvider].to(bindNamed(default))) else Nil
 
   def bindNamed(name: String): BindingKey[DatabaseConfigProvider] =

--- a/src/core/src/test/scala/play/api/db/slick/DefaultSlickApiSpec.scala
+++ b/src/core/src/test/scala/play/api/db/slick/DefaultSlickApiSpec.scala
@@ -16,10 +16,10 @@ class DefaultSlickApiSpec extends Specification { self =>
   // A new injector should be created to ensure each test is independent of each other
   def injector: Injector = GuiceApplicationBuilder(configuration = TestData.configuration).injector()
 
-  def hooks(lifecycle: DefaultApplicationLifecycle): Seq[_] = {
+  def hooks(lifecycle: DefaultApplicationLifecycle): Seq[?] = {
     val hooksField = lifecycle.getClass.getDeclaredField("hooks")
     hooksField.setAccessible(true)
-    hooksField.get(lifecycle).asInstanceOf[ConcurrentLinkedDeque[_]].toArray().toSeq
+    hooksField.get(lifecycle).asInstanceOf[ConcurrentLinkedDeque[?]].toArray().toSeq
   }
 
   "DefaultSlickApi" should {

--- a/src/evolutions/src/main/scala/play/api/db/slick/evolutions/EvolutionsModule.scala
+++ b/src/evolutions/src/main/scala/play/api/db/slick/evolutions/EvolutionsModule.scala
@@ -11,7 +11,7 @@ import play.api.inject.Module
 
 @Singleton
 class EvolutionsModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
+  def bindings(environment: Environment, configuration: Configuration): Seq[Binding[?]] = {
     Seq(bind[DBApi].to[DBApiAdapter].in[Singleton])
   }
 }


### PR DESCRIPTION

old wildcard syntax `[_]` is deprecated in latest Scala 3.

```
Welcome to Scala 3.6.3 (21.0.5, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                           
scala> val a: List[_] = Nil
1 warning found
-- Warning: --------------------------------------------------------------------
1 |val a: List[_] = Nil
  |            ^
  |        `_` is deprecated for wildcard arguments of types: use `?` instead
val a: List[?] = List()
                                                                                                                                           
scala> val b: List[?] = Nil
val b: List[?] = List()
```